### PR TITLE
Fix an error with meow in cli.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 cache/
 reports/
+.DS_Store
 
 # Created by https://www.toptal.com/developers/gitignore/api/node
 # Edit at https://www.toptal.com/developers/gitignore?templates=node

--- a/cli.js
+++ b/cli.js
@@ -194,7 +194,6 @@ const cli = meow(createHelpText(), {
   allowUnknownFlags: false,
   importMeta: import.meta,
   inferType: false,
-  input: [],
   flags: CLI_FLAGS,
 })
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,3 +1,26 @@
+import {spawnSync} from 'node:child_process'
+import {readFileSync} from 'node:fs'
+import {fileURLToPath} from 'node:url'
+
+const cliPath = fileURLToPath(new URL('../cli.js', import.meta.url))
+const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
+
+/**
+ * Run the CLI in a child process so the entrypoint is exercised end to end.
+ * @param {string[]} args - CLI arguments
+ * @returns {import('node:child_process').SpawnSyncReturns<string>} Child process result
+ */
+function runCli(args) {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      DEBUG: 'false',
+      GITHUB_TOKEN: '',
+    },
+  })
+}
+
 describe('cli', () => {
   beforeEach(() => {})
 
@@ -7,13 +30,22 @@ describe('cli', () => {
    * Test CLI help functionality
    */
   test('should display help information with --help flag', () => {
-    // TODO: Implement test logic
+    const result = runCli(['--help'])
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('Usage')
+    expect(result.stdout).toContain('action-reporting-cli')
   })
 
   /**
    * Test CLI version functionality
    */
   test('should display version information with --version flag', () => {
-    // TODO: Implement test logic
+    const result = runCli(['--version'])
+    const outputLines = result.stdout.trim().split('\n')
+    const lastLine = outputLines[outputLines.length - 1]
+
+    expect(result.status).toBe(0)
+    expect(lastLine).toBe(packageJson.version)
   })
 })


### PR DESCRIPTION
## Description

The `meow` CLI parser was configured with `input: []`, which caused a type error (see #148). This change removes the invalid `input` option from the `meow()` call in `cli.js`. Additionally, the previously stubbed CLI tests (`--help` and `--version`) are now fully implemented using a child process helper, and `.DS_Store` is added to `.gitignore`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Dependency update

## Related Issues

Closes: #148

## Changes Made

- Removed the invalid `input: []` option from the `meow()` configuration in `cli.js`, fixing a runtime type error
- Implemented end-to-end CLI tests for `--help` and `--version` flags using `spawnSync` in `test/cli.test.js`
- Added `.DS_Store` to `.gitignore`

## Testing

Please describe the tests you ran and how to reproduce them:

```
Commands to test:
1. npm test
2. node cli.js --help
3. node cli.js --version
```

## Checklist

- [x] My commits are signed with a verified signature (required)
- [x] I have followed the code style guidelines in this project
- [x] I have updated the README.md if applicable
- [x] I have added tests for new functionality
- [x] All tests pass locally (`npm test`, including pretest linting)
- [x] I have run the formatter (`npm run format`)
- [ ] I have added/updated documentation for any new or changed functionality
- [x] My pull request title is descriptive and follows Gitmoji conventions

## Additional Context

The `meow` library does not accept an `input` property in its options object. Passing `input: []` caused a type error at runtime. The fix simply removes that property, letting `meow` handle positional input with its default behavior.
